### PR TITLE
[mac] Don't segfault on ports with missing properties / Use an empty string for missing port properties

### DIFF
--- a/include/libremidi/backends/coremidi/helpers.hpp
+++ b/include/libremidi/backends/coremidi/helpers.hpp
@@ -30,7 +30,8 @@ namespace
 static inline std::string get_string_property(MIDIObjectRef object, CFStringRef property) noexcept
 {
   CFStringRef res;
-  MIDIObjectGetStringProperty(object, property, &res);
+  if (MIDIObjectGetStringProperty(object, property, &res) || !res)
+    return {};
 
   char name[256];
   CFStringGetCString(res, name, sizeof(name), kCFStringEncodingUTF8);


### PR DESCRIPTION
MacOS 14, Apple Silicon

Found a bug when I modified the ``midiprobe`` example to enumerate virtual ports created by the ``coremidi_share`` example:
```
libremidi::observer midi{ {.track_virtual = true },libremidi::observer_configuration_for(api) };
```

When running the ``coremidi_share`` in one terminal, and  the modified ``mididprobe`` in another, ``midiprobe`` would segfault inside ``get_string_property`` due to nullptr dereference of ``CFStringRef res``  inside ``CFStringGetCString(res,...)``



