### PR TITLE
[c] keep API enum in sync with api.hpp.

### DIFF
--- a/include/libremidi/libremidi-c.h
+++ b/include/libremidi/libremidi-c.h
@@ -45,23 +45,25 @@ enum libremidi_timestamp_mode
 
 enum libremidi_api
 {
-  UNSPECIFIED, /*!< Search for a working compiled API. */
+  UNSPECIFIED = 0x0, /*!< Search for a working compiled API. */
 
   // MIDI 1.0 APIs
-  COREMIDI,    /*!< macOS CoreMidi API. */
-  ALSA_SEQ,    /*!< Linux ALSA Sequencer API. */
-  ALSA_RAW,    /*!< Linux Raw ALSA API. */
-  JACK_MIDI,   /*!< JACK Low-Latency MIDI Server API. */
-  WINDOWS_MM,  /*!< Microsoft Multimedia MIDI API. */
-  WINDOWS_UWP, /*!< Microsoft WinRT MIDI API. */
-  WEBMIDI,     /*!< Web MIDI API through Emscripten */
-  PIPEWIRE,    /*!< PipeWire */
+  COREMIDI = 0x1, /*!< macOS CoreMidi API. */
+  ALSA_SEQ,       /*!< Linux ALSA Sequencer API. */
+  ALSA_RAW,       /*!< Linux Raw ALSA API. */
+  JACK_MIDI,      /*!< JACK Low-Latency MIDI Server API. */
+  WINDOWS_MM,     /*!< Microsoft Multimedia MIDI API. */
+  WINDOWS_UWP,    /*!< Microsoft WinRT MIDI API. */
+  WEBMIDI,        /*!< Web MIDI API through Emscripten */
+  PIPEWIRE,       /*!< PipeWire */
+  KEYBOARD,       /*!< Computer keyboard input */
 
   // MIDI 2.0 APIs
-  ALSA_RAW_UMP,          /*!< Raw ALSA API for MIDI 2.0 */
+  ALSA_RAW_UMP = 0x1000, /*!< Raw ALSA API for MIDI 2.0 */
   ALSA_SEQ_UMP,          /*!< Linux ALSA Sequencer API for MIDI 2.0 */
   COREMIDI_UMP,          /*!< macOS CoreMidi API for MIDI 2.0. Requires macOS 11+ */
   WINDOWS_MIDI_SERVICES, /*!< Windows API for MIDI 2.0. Requires Windows 11 */
+  KEYBOARD_UMP,          /*!< Computer keyboard input */
 
   DUMMY /*!< A compilable but non-functional API. */
 };


### PR DESCRIPTION
There were new enum entries in `libremidi_api` at 13b0d84, but they were not kept in sync in `libremidi-c.h`. It resulted in that UMP APIs (I confirmed it on coremidi_ump) `libremidi_midi_observer_enumerate_input_ports()` and `libremidi_midi_observer_enumerate_output_ports()` do not return the platform ports anymore.

This patch should fix the issue.