### PR TITLE
[writer] Change ticksPerQuarterNote to be uint16_t

### DIFF
--- a/include/libremidi/writer.hpp
+++ b/include/libremidi/writer.hpp
@@ -34,7 +34,7 @@ namespace libremidi
 struct LIBREMIDI_EXPORT writer
 {
 public:
-  int ticksPerQuarterNote{120};
+  uint16_t ticksPerQuarterNote{120};
   std::vector<midi_track> tracks;
 
   void add_event(int tick, int track, const message& m);


### PR DESCRIPTION
This is passed to util::write_uint16_be(), which could cause a truncation if it was set to a value that didn't fit into a 16-bit unsigned integer.

This produced the following compiler warning for me:

	/build/source/libremidi/include/libremidi/writer.cpp: In member function 'void libremidi::writer::write(std::ostream&) const':
	/build/source/libremidi/include/libremidi/writer.cpp:205:30: error: conversion from 'int' to 'uint16_t' {aka short unsigned int'} may change value [-Werror=conversion]
	  205 |   util::write_uint16_be(out, ticksPerQuarterNote);
	      |                              ^~~~~~~~~~~~~~~~~~~
	cc1plus: all warnings being treated as errors