### PR TITLE
Add cstdint include to fix vendored compilation

### DIFF
--- a/include/libremidi/message.hpp
+++ b/include/libremidi/message.hpp
@@ -2,6 +2,7 @@
 #include <libremidi/config.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <span>
 #include <vector>
 #if defined(__cpp_exceptions)


### PR DESCRIPTION
I have no idea why, but this fixes the Linux build of my Haskell bindings (missing uint8_t). If not appropriate to mainline, go ahead and dismiss the PR - I can put it in a local patch.