### PR TITLE
cmake: allow using system-installed readerwriterqueue

### DIFF
--- a/cmake/libremidi.deps.cmake
+++ b/cmake/libremidi.deps.cmake
@@ -40,11 +40,15 @@ if(NOT LIBREMIDI_NO_PIPEWIRE)
   set(LIBREMIDI_NEEDS_READERWRITERQUEUE 1)
 endif()
 if(LIBREMIDI_NEEDS_READERWRITERQUEUE AND NOT TARGET readerwriterqueue)
-  FetchContent_Declare(
-      readerwriterqueue
-      GIT_REPOSITORY https://github.com/cameron314/readerwriterqueue
-      GIT_TAG        master
-  )
+  find_package(readerwriterqueue)
 
-  FetchContent_MakeAvailable(readerwriterqueue)
+  if(NOT readerwriterqueue_FOUND)
+    FetchContent_Declare(
+        readerwriterqueue
+        GIT_REPOSITORY https://github.com/cameron314/readerwriterqueue
+        GIT_TAG        master
+    )
+
+    FetchContent_MakeAvailable(readerwriterqueue)
+  endif()
 endif()


### PR DESCRIPTION
`readerwriterqueue` can be installed into system directories, and [a number of distributions already package it](https://repology.org/project/readerwriterqueue/versions). Where possible, use the system-provided copy rather than requiring it to be downloaded via `FetchContent`.

Currently the default behavior provided by this PR is to use the system-provided copy if available; if preferred, this can also be inverted to prefer the `FetchContent` and only rely on the system version via an explicit option.

The objective of this PR is to allow downstream packagers to rely on their own system-installed copies of dependencies where possible rather than have them be downloaded at compile time. (I'd like to do the same for `ni-midi2`, but the build system for `ni-midi2` does not yet facilitate installing it into system directories.)

If this change is not accepted, downstream packagers can still point `FetchContent` to a system-provided copy of `readerwriterqueue`, e.g. `-DFETCHCONTENT_SOURCE_DIR_READERWRITERQUEUE:PATH=/usr/lib/cmake/readerwriterqueue`.