### PR TITLE
c api: added port handle getter

### DIFF
--- a/examples/c_api.c
+++ b/examples/c_api.c
@@ -36,7 +36,13 @@ void on_input_port_found(void* ctx, const libremidi_midi_in_port* port)
   if (ret != 0)
     return;
 
-  printf("input: %s\n", name);
+  uint64_t handle = -1;
+
+  ret = libremidi_midi_in_port_handle(port, &handle);
+  if (ret != 0)
+    return;
+
+  printf("input %d: %s\n", handle, name);
   fflush(stdout);
 
   enumerated_ports* e = (enumerated_ports*)ctx;
@@ -53,7 +59,13 @@ void on_output_port_found(void* ctx, const libremidi_midi_out_port* port)
   if (ret != 0)
     return;
 
-  printf("output: %s\n", name);
+  uint64_t handle = -1;
+
+  ret = libremidi_midi_out_port_handle(port, &handle);
+  if (ret != 0)
+    return;
+
+  printf("output %d: %s\n", handle, name);
   fflush(stdout);
 
   enumerated_ports* e = (enumerated_ports*)ctx;

--- a/include/libremidi/libremidi-c.cpp
+++ b/include/libremidi/libremidi-c.cpp
@@ -123,6 +123,16 @@ int libremidi_midi_in_port_name(const libremidi_midi_in_port* port, const char**
   return 0;
 }
 
+int libremidi_midi_in_port_handle(const libremidi_midi_in_port* port, uint64_t* handle)
+{
+  if (!port || !handle)
+    return -EINVAL;
+
+  auto& p = *reinterpret_cast<const libremidi::input_port*>(port);
+  *handle = static_cast<uint64_t>(p.port);
+  return 0;
+}
+
 int libremidi_midi_out_port_clone(
     const libremidi_midi_out_port* port, libremidi_midi_out_port** dst)
 {
@@ -149,6 +159,16 @@ int libremidi_midi_out_port_name(
   auto& p = *reinterpret_cast<const libremidi::output_port*>(port);
   *name = p.port_name.data();
   *len = p.port_name.size();
+  return 0;
+}
+
+int libremidi_midi_out_port_handle(const libremidi_midi_out_port* port, uint64_t* handle)
+{
+  if (!port || !handle)
+    return -EINVAL;
+
+  auto& p = *reinterpret_cast<const libremidi::output_port*>(port);
+  *handle = static_cast<uint64_t>(p.port);
   return 0;
 }
 

--- a/include/libremidi/libremidi-c.h
+++ b/include/libremidi/libremidi-c.h
@@ -199,6 +199,10 @@ int libremidi_midi_in_port_name(
     const libremidi_midi_in_port* port, const char** name, size_t* len);
 
 LIBREMIDI_EXPORT
+int libremidi_midi_in_port_handle(
+    const libremidi_midi_in_port* port, uint64_t* handle);
+
+LIBREMIDI_EXPORT
 int libremidi_midi_out_port_clone(
     const libremidi_midi_out_port* port, libremidi_midi_out_port** dst);
 
@@ -208,6 +212,10 @@ int libremidi_midi_out_port_free(libremidi_midi_out_port* port);
 LIBREMIDI_EXPORT
 int libremidi_midi_out_port_name(
     const libremidi_midi_out_port* port, const char** name, size_t* len);
+
+LIBREMIDI_EXPORT
+int libremidi_midi_out_port_handle(
+    const libremidi_midi_out_port* port, uint64_t* handle);
 
 /// Observer API
 LIBREMIDI_EXPORT


### PR DESCRIPTION
Added a getter to get a port's handle. Useful when two ports have the same name.