### PR TITLE
Initialize m2 to silence MSVC C4701 warning

### DIFF
--- a/include/libremidi/cmidi2.hpp
+++ b/include/libremidi/cmidi2.hpp
@@ -2768,7 +2768,7 @@ cmidi2_convert_midi1_to_ump(cmidi2_midi_conversion_context* context)
       else
       {
         // generate MIDI2 UMPs
-        uint64_t m2;
+        uint64_t m2 = 0;
         const int8_t NO_ATTRIBUTE_TYPE = 0;
         const int16_t NO_ATTRIBUTE_DATA = 0;
         bool bankValid, bankMsbValid, bankLsbValid;


### PR DESCRIPTION
`m2` is guarded by `skipEmitUmp` so it's never read uninitialized, but MSVC can't track the correlation across the two switch statements and emits C4701.

Zero-initialize to silence the warning.