### PR TITLE
Fix: Flex data not handled

### DIFF
--- a/include/libremidi/cmidi2.hpp
+++ b/include/libremidi/cmidi2.hpp
@@ -359,6 +359,8 @@ LIBREMIDI_STATIC uint8_t cmidi2_ump_get_num_bytes(uint32_t data)
     case CMIDI2_MESSAGE_TYPE_SYSEX7:
       return 8;
     case CMIDI2_MESSAGE_TYPE_SYSEX8_MDS:
+    case CMIDI2_MESSAGE_TYPE_FLEX_DATA:
+    case CMIDI2_MESSAGE_TYPE_UMP_STREAM:
       return 16;
   }
   return 0xFF; /* wrong */


### PR DESCRIPTION
`cmidi2_ump_get_num_bytes()` was not handling flex data