### PR TITLE
emscripten: fix WebMIDI backend (available() check + _malloc export)

### DIFF
--- a/cmake/libremidi.emscripten.cmake
+++ b/cmake/libremidi.emscripten.cmake
@@ -7,4 +7,9 @@ set(LIBREMIDI_HAS_EMSCRIPTEN 1)
 
 set(CMAKE_EXECUTABLE_SUFFIX .html)
 target_compile_definitions(libremidi ${_public} LIBREMIDI_EMSCRIPTEN)
-target_link_options(libremidi ${_public} "SHELL:-s 'EXPORTED_FUNCTIONS=[\"_main\", \"_free\", \"_libremidi_devices_poll\", \"_libremidi_devices_input\"]'")
+# The WebMIDI backend calls Module._malloc (and _free) from JS to copy incoming
+# message bytes onto the heap, and uses the HEAPU8 / UTF8ToString / stringToUTF8
+# / lengthBytesUTF8 runtime helpers. Export all of them, otherwise receiving a
+# message throws e.g. "Module._malloc is not a function".
+target_link_options(libremidi ${_public} "SHELL:-s 'EXPORTED_FUNCTIONS=[\"_main\", \"_malloc\", \"_free\", \"_libremidi_devices_poll\", \"_libremidi_devices_input\"]'")
+target_link_options(libremidi ${_public} "SHELL:-s 'EXPORTED_RUNTIME_METHODS=[\"HEAPU8\", \"UTF8ToString\", \"stringToUTF8\", \"lengthBytesUTF8\"]'")

--- a/include/libremidi/backends/emscripten/midi_access.hpp
+++ b/include/libremidi/backends/emscripten/midi_access.hpp
@@ -32,7 +32,7 @@ public:
 
   bool available() const noexcept
   {
-    return EM_ASM_INT(return typeof globalThis.__libreMidi_access !== undefined;);
+    return EM_ASM_INT(return typeof globalThis.__libreMidi_access !== 'undefined';);
   }
 
   int input_count() const noexcept


### PR DESCRIPTION
While using the Emscripten / WebMIDI backend I hit two issues that make it unusable at runtime. Both are small, independent fixes.

### 1. `midi_access_emscripten::available()` is always true

```cpp
return EM_ASM_INT(return typeof globalThis.__libreMidi_access !== undefined;);
```

`typeof x` evaluates to a **string**, so `typeof x !== undefined` is always `true` (a string is never `=== undefined`). As a result `available()` never reports "not ready", and the `if (!available()) return;` guards never fire.

Because `navigator.requestMIDIAccess()` resolves asynchronously (a frame or more after start), any enumeration done before it resolves runs `load_current_infos()` against a still-`undefined` `globalThis.__libreMidi_access`, throwing:

```
TypeError: Cannot read properties of undefined (reading 'inputs')
```

Fix: compare against the string `'undefined'`.

### 2. `_malloc` (and the runtime helpers) are not exported

`cmake/libremidi.emscripten.cmake` exports `_free` but not `_malloc`, even though the backend calls `Module._malloc` (e.g. `_arrayToHeap` in `start_stream`, and the `get_js_string` macro). Receiving a MIDI message throws:

```
TypeError: Module._malloc is not a function
```

The backend also uses `HEAPU8`, `UTF8ToString`, `stringToUTF8` and `lengthBytesUTF8`, which are not exported by default on recent Emscripten. Fix: add `_malloc` to `EXPORTED_FUNCTIONS` and add the runtime methods to `EXPORTED_RUNTIME_METHODS`.

### Testing

With both fixes, a WebGPU/Emscripten app links and runs in Chrome: device enumeration waits for access cleanly, and incoming MIDI messages are received without throwing. (Verified via a TrussC app linking libremidi v5.4.3 + these patches.)