### PR TITLE
winmidi: fix input dropped when a group terminal block's Number() isn't its group index

### DIFF
--- a/include/libremidi/backends/winmidi/midi_in.hpp
+++ b/include/libremidi/backends/winmidi/midi_in.hpp
@@ -100,7 +100,12 @@ public:
     if (!ep || !gp)
       return std::errc::address_not_available;
 
-    m_group_filter = port.port - 1;
+    // port.port is the Group Terminal Block Number(), which is not necessarily equal to
+    // the UMP group index the block spans. For example a USB MIDI 1.0 device may expose
+    // its input GTB as Number()==2 while its messages arrive on group 0. Using
+    // `port.port - 1` as the group filter therefore silently drops all input from such
+    // devices. Filter on the resolved block's actual first group instead.
+    m_group_filter = gp.FirstGroup().Index();
 
     try
     {


### PR DESCRIPTION
The input group filter keeps only messages whose group is `port.port - 1`, i.e. it
treats a group terminal block's `Number()` as its UMP group index. Those two are
independent, so whether they line up depends on how a given device numbers its
blocks: input works on some devices and silently fails on others.

When they don't match, `process_message` drops every incoming message. The device
still connects, and output works (the send path has no such filter), but no input
ever arrives.

Fix: filter on the resolved block's actual first group (`gp.FirstGroup().Index()`)
instead of `Number() - 1`.

Two related issues are left as-is for now: a GTB spanning several groups still only
passes its first group, and a device exposing both function blocks and group
terminal blocks can still mismatch, since `get_port` only resolves GTBs.
