### PR TITLE
pipewire: hold the thread-loop lock across blocking invokes; buffer size/stride as ranges

### DIFF
--- a/include/libremidi/backends/linux/pipewire/context.hpp
+++ b/include/libremidi/backends/linux/pipewire/context.hpp
@@ -308,7 +308,13 @@ public:
         }
         return 0;
       };
-      pw_loop_invoke(m_loop, trampoline, 0, nullptr, 0, /*block=*/true, &f);
+      // A blocking pw_loop_invoke from a foreign thread fires the loop
+      // control hooks (thread-loop unlock before the wait / lock after),
+      // which REQUIRE the caller to hold the thread-loop lock. Calling
+      // without it underflows the recurse counter (refused unlock) and
+      // then acquires the mutex on the way out, deadlocking the loop.
+      with_lock(
+          [&] { pw_loop_invoke(m_loop, trampoline, 0, nullptr, 0, /*block=*/true, &f); });
     }
     else
     {
@@ -330,7 +336,9 @@ public:
         }
         return 0;
       };
-      pw_loop_invoke(m_loop, trampoline, 0, nullptr, 0, /*block=*/true, &p);
+      // See the void branch: blocking invokes require the thread-loop lock.
+      with_lock(
+          [&] { pw_loop_invoke(m_loop, trampoline, 0, nullptr, 0, /*block=*/true, &p); });
       return std::move(*p.result);
     }
   }

--- a/include/libremidi/backends/linux/pipewire/format.hpp
+++ b/include/libremidi/backends/linux/pipewire/format.hpp
@@ -320,10 +320,15 @@ inline const spa_pod* format_negotiation::build_buffers_param(
       data_type = (1u << SPA_DATA_MemPtr);
       break;
   }
+  // size/stride are RANGES with our tight computation as the minimum:
+  // producers commonly deliver row-padded buffers (GPU-allocated strides),
+  // and a fixed Int here fails the param intersection against any producer
+  // whose size differs — killing the link instead of accepting padding.
   return reinterpret_cast<const spa_pod*>(spa_pod_builder_add_object(
       &builder, SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers, SPA_PARAM_BUFFERS_buffers,
       SPA_POD_CHOICE_RANGE_Int(8, 2, 16), SPA_PARAM_BUFFERS_blocks, SPA_POD_Int(blocks),
-      SPA_PARAM_BUFFERS_size, SPA_POD_Int(size), SPA_PARAM_BUFFERS_stride, SPA_POD_Int(stride),
+      SPA_PARAM_BUFFERS_size, SPA_POD_CHOICE_RANGE_Int(size, size, INT32_MAX),
+      SPA_PARAM_BUFFERS_stride, SPA_POD_CHOICE_RANGE_Int(stride, stride, INT32_MAX),
       SPA_PARAM_BUFFERS_dataType, SPA_POD_CHOICE_FLAGS_Int(data_type)));
 }
 


### PR DESCRIPTION
Two fixes for the shared PipeWire context, found while round-trip-testing ossia score's PipeWire video path against a live 1.3.0 daemon.

## 1. `context::invoke_sync` corrupts the thread-loop mutex

`invoke_sync` issued `pw_loop_invoke(..., block=true, ...)` from foreign threads **without holding the thread-loop lock**. PipeWire's blocking-invoke path unconditionally fires the loop-control hooks around its wait (`pw_thread_loop`'s `impl_before`/`impl_after` — i.e. unlock/lock), which exist to release the *caller's* lock while it blocks; the API contract is that the caller holds it.

Without the lock:
- `do_unlock` underflows the recurse counter (`'this->recurse > 0' failed at thread-loop.c:62` on stderr) and the unlock is refused;
- `impl_after` then **acquires** the mutex on the way out, so the calling thread exits owning the loop mutex forever;
- the loop thread blocks in `do_lock` on its next iteration, and any later `pw_thread_loop_stop` deadlocks in `pthread_join`.

Proven by rebuilding libpipewire with an instrumented `thread-loop.c` (abort on recurse underflow): the guilty stack was `invoke_sync` ← `context::unsubscribe` ← `subscription` dtor. Every consumer that destroys a subscription or uses `invoke_sync` off-loop hits this eventually.

Fix: wrap the two blocking `pw_loop_invoke` calls in `with_lock` — the hooks then release/retake the lock during the wait exactly as designed. `invoke_async` (block=false) is unaffected.

## 2. `format_negotiation::build_buffers_param` rejects padded strides

`SPA_PARAM_BUFFERS_size`/`stride` were advertised as fixed Ints, so any producer with padded rows (GPU-allocated buffers routinely pad strides) failed the buffers-param intersection and the link died before a single frame. Now advertised as `CHOICE_RANGE(tight, tight, INT32_MAX)`; consumers must read `chunk->stride`/`size` per frame anyway.

Both verified with score's new `PipewireRoundtrip` harness (26/26 format×transport cells pass, including padded-stride producers; the deadlock repro'd 100% before the fix and is gone after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rZgzE8JjWvHDtaVUhxpLE