### PR TITLE
emscripten: fix observer update() call (missing notify arg)

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,47 @@
+name: Emscripten
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wasm:
+    name: WebAssembly
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y ninja-build
+
+    - uses: mymindstorm/setup-emsdk@v14
+
+    # Build the library and the emscripten example so the WebMIDI backend
+    # (backends/emscripten/*) is actually compiled -- it is only ever built for
+    # wasm, so the native/mingw/android/etc. jobs never exercise it.
+    - name: Configure
+      run: |
+        emcmake cmake -S . -B build -GNinja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DLIBREMIDI_LIBRARY_MODE=LIBRARY \
+          -DLIBREMIDI_EXAMPLES=1
+
+    - name: Build
+      run: cmake --build build

--- a/include/libremidi/backends/emscripten/midi_access.hpp
+++ b/include/libremidi/backends/emscripten/midi_access.hpp
@@ -175,7 +175,7 @@ public:
 
     for (auto& obs : m_observers)
     {
-      obs->update(m_current_inputs, m_current_outputs);
+      obs->update(m_current_inputs, m_current_outputs, true);
     }
   }
 


### PR DESCRIPTION
The emscripten MIDI backend's `observer_emscripten::update()` takes `(inputs, outputs, bool notify)`, but the `devices_poll()` call site in `midi_access.hpp` still passed only 2 args:

```
midi_access.hpp:178:  obs->update(m_current_inputs, m_current_outputs);        // 2 args
observer.hpp:25:      void update(…inputs, …outputs, bool notify);              // 3 args
```

This breaks any wasm build (`too few arguments to function call`). The emscripten backend is compiled only for wasm, so non-wasm CI never caught it. `devices_poll()` detects hotplugged devices → `notify = true`.

Found while reviving the ossia/score wasm build (ossia/score#2034).

🤖 Generated with [Claude Code](https://claude.com/claude-code)