### PR TITLE
config: use __declspec(dllexport) on all Windows (MinGW/Clang), not just MSVC

### DIFF
--- a/include/libremidi/config.hpp
+++ b/include/libremidi/config.hpp
@@ -46,7 +46,7 @@
 
 // Dynamic exports
 #if defined(LIBREMIDI_EXPORTS) || defined(LIBREMIDI_MODULE_BUILD)
-  #if defined(_MSC_VER)
+  #if defined(_WIN32)
     #define LIBREMIDI_EXPORT __declspec(dllexport)
   #elif defined(__GNUC__) || defined(__clang__)
     #define LIBREMIDI_EXPORT __attribute__((visibility("default")))

--- a/include/libremidi/libremidi-c.h
+++ b/include/libremidi/libremidi-c.h
@@ -6,7 +6,7 @@
 #include <stdint.h>
 
 #if defined(LIBREMIDI_EXPORTS)
-  #if defined(_MSC_VER)
+  #if defined(_WIN32)
     #define LIBREMIDI_EXPORT __declspec(dllexport)
   #elif defined(__GNUC__) || defined(__clang__)
     #define LIBREMIDI_EXPORT __attribute__((visibility("default")))


### PR DESCRIPTION
### Problem

`LIBREMIDI_EXPORT` resolved to `__attribute__((visibility("default")))` on the GCC/Clang path:

```cpp
#if defined(LIBREMIDI_EXPORTS) || defined(LIBREMIDI_MODULE_BUILD)
  #if defined(_MSC_VER)
    #define LIBREMIDI_EXPORT __declspec(dllexport)
  #elif defined(__GNUC__) || defined(__clang__)
    #define LIBREMIDI_EXPORT __attribute__((visibility("default")))
  #endif
```

But `visibility` is an **ELF** concept. On **Windows PE/COFF** (MinGW-GCC and Clang targeting `*-w64-windows-gnu`) it is silently inert — it produces **no PE export**. So on those toolchains:

- a **shared** libremidi (`.dll`) built with MinGW/Clang exports **none** of its API, and
- a **static** libremidi re-exported from an executable (e.g. a host that JIT-compiles plugins referencing `libremidi::reader::parse`) exports nothing either.

Only the MSVC branch got `__declspec(dllexport)`.

### Fix

Key the `dllexport` branch on `_WIN32` so it covers all Windows compilers (MSVC **and** MinGW/Clang). `__declspec(dllexport)` is supported by GCC/Clang on mingw and is the correct PE mechanism.

### Verification

On `x86_64-w64-windows-gnu`, compiling:
```cpp
__attribute__((visibility("default"))) int vis_func() { return 1; }
__declspec(dllexport)                   int dll_func() { return 2; }
```
`llvm-objdump -s --section=.drectve` shows a `-export:` directive only for `dll_func` — `vis_func` produces none. Confirmed against the real symptom: a MinGW/Clang-built static libremidi shows **0** `-export:` directives; after this change its public API (`reader`, `observer`, `available_apis`, …) exports correctly.

This should be validated by the existing MSYS/MinGW CI matrix.