### PR TITLE
CI: build in parallel

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -207,8 +207,8 @@ jobs:
     - name: Build
       if: matrix.config.name != 'Tarball'
       run: |
-        cmake --build build --config Debug
-        cmake --build build --config Debug --target install
+        cmake --build build --parallel --config Debug
+        cmake --build build --parallel --config Debug --target install
 
     - name: Test
       if: matrix.config.name != 'Tarball' && matrix.config.name != 'iOS' && matrix.library_mode != 'MODULE'
@@ -218,7 +218,7 @@ jobs:
         #   sudo modprobe snd-virmidi midi_devs=1
         # fi
 
-        cmake --build build --config Debug --target ${{ matrix.config.test_target }}
+        cmake --build build --parallel --config Debug --target ${{ matrix.config.test_target }}
 
       shell: bash
 
@@ -261,9 +261,9 @@ jobs:
             -DCMAKE_CTEST_ARGUMENTS="--rerun-failed;--output-on-failure" \
             -DCMAKE_INSTALL_PREFIX=install
 
-          cmake --build build
+          cmake --build build --parallel
           if [ "${{ matrix.library_mode }}" != "MODULE" ]; then
-            cmake --build build --target install
+            cmake --build build --parallel --target install
             cmake --build build --target test
           fi
 
@@ -337,8 +337,8 @@ jobs:
 
     - name: Build
       run: |
-        cmake --build build --config Debug
-        cmake --build build --config Debug --target install
+        cmake --build build --parallel --config Debug
+        cmake --build build --parallel --config Debug --target install
 
     - name: Test
       if: matrix.library_mode != 'MODULE'

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -103,7 +103,7 @@ jobs:
       shell: bash
       run: |
         export ASAN_OPTIONS=detect_leaks=0
-        ${{matrix.config.environment}} cmake --build build --config Debug
+        ${{matrix.config.environment}} cmake --build build --parallel --config Debug
 
     - name: Test
       if: runner.os == 'Windows'

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -59,8 +59,8 @@ jobs:
             -DCMAKE_CTEST_ARGUMENTS="--rerun-failed;--output-on-failure" \
             -DCMAKE_INSTALL_PREFIX=install
 
-          cmake --build build-debug
-          cmake --build build-debug --target install
+          cmake --build build-debug --parallel
+          cmake --build build-debug --parallel --target install
 
       - name: Test debug
         shell: msys2 {0}
@@ -79,8 +79,8 @@ jobs:
             -DCMAKE_CTEST_ARGUMENTS="--rerun-failed;--output-on-failure" \
             -DCMAKE_INSTALL_PREFIX=install
 
-          cmake --build build-release
-          cmake --build build-release --target install
+          cmake --build build-release --parallel
+          cmake --build build-release --parallel --target install
 
       - name: Test release
         shell: msys2 {0}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -44,4 +44,4 @@ jobs:
           -DLIBREMIDI_EXAMPLES=1
 
     - name: Build
-      run: cmake --build build
+      run: cmake --build build --parallel


### PR DESCRIPTION
`cmake --build` defaults to a single job under the Makefiles generator, so these builds compiled on one core no matter how many the machine has.

`--parallel` lets CMake choose the job count. It is a no-op where the generator already parallelises (Ninja), so it is safe to apply uniformly.

Test targets are left alone — running tests in parallel is a separate decision.