### PR TITLE
pipewire: don't treat per-object errors as connection loss, don't tear down a shared context

### DIFF
--- a/cmake/libremidi.tests.cmake
+++ b/cmake/libremidi.tests.cmake
@@ -72,7 +72,8 @@ add_test(NAME rawio_test COMMAND rawio_test)
 # each skips with exit 0 when no daemon is reachable and arms a watchdog so a
 # lock-corruption regression fails instead of hanging.
 if(LIBREMIDI_HAS_PIPEWIRE)
-  foreach(_pwtest pipewire_context_sync pipewire_context_reconnect pipewire_context_subscriptions)
+  foreach(_pwtest pipewire_context_sync pipewire_context_reconnect pipewire_context_subscriptions
+                  pipewire_context_error_scope)
     add_executable(${_pwtest}_test tests/integration/${_pwtest}.cpp)
     target_link_libraries(${_pwtest}_test PRIVATE libremidi)
     add_test(NAME ${_pwtest}_test COMMAND ${_pwtest}_test)

--- a/cmake/libremidi.tests.cmake
+++ b/cmake/libremidi.tests.cmake
@@ -73,7 +73,7 @@ add_test(NAME rawio_test COMMAND rawio_test)
 # lock-corruption regression fails instead of hanging.
 if(LIBREMIDI_HAS_PIPEWIRE)
   foreach(_pwtest pipewire_context_sync pipewire_context_reconnect pipewire_context_subscriptions
-                  pipewire_context_error_scope)
+                  pipewire_context_error_scope pipewire_context_shared_teardown)
     add_executable(${_pwtest}_test tests/integration/${_pwtest}.cpp)
     target_link_libraries(${_pwtest}_test PRIVATE libremidi)
     add_test(NAME ${_pwtest}_test COMMAND ${_pwtest}_test)

--- a/include/libremidi/backends/linux/pipewire/context.cpp
+++ b/include/libremidi/backends/linux/pipewire/context.cpp
@@ -17,7 +17,7 @@ std::shared_ptr<context> shared_context(context::config cfg) noexcept
 
   std::lock_guard lock{mtx};
   if (auto p = weak.lock())
-    return p;
+    return context::make_shared_holder(std::move(p));
 
   auto inst = shared_instance();
   if (!inst)
@@ -27,7 +27,7 @@ std::shared_ptr<context> shared_context(context::config cfg) noexcept
   if (!ctx)
     return {};
   weak = ctx;
-  return ctx;
+  return context::make_shared_holder(std::move(ctx));
 }
 
 }

--- a/include/libremidi/backends/linux/pipewire/context.hpp
+++ b/include/libremidi/backends/linux/pipewire/context.hpp
@@ -846,12 +846,20 @@ private:
     }
   }
 
+  // pw_core_events::error reports the proxy the error belongs to in `id`;
+  // PW_ID_CORE is the connection itself, anything else is a per-object error
+  // that says nothing about the socket.
   static void on_core_error(
-      void* data, std::uint32_t /*id*/, int /*seq*/, int res, const char* /*message*/) noexcept
+      void* data, std::uint32_t id, int /*seq*/, int res, const char* /*message*/) noexcept
   {
     auto* self = static_cast<context*>(data);
+    if (id != PW_ID_CORE)
+      return;
+
     self->m_sync_error.store(res, std::memory_order_release);
-    if (res == -EPIPE || res == -ECONNRESET || res == -ENOENT || res == -ENOTCONN)
+    // -ENOENT is "no such object/factory", which is recoverable; connection
+    // loss surfaces as a socket error.
+    if (res == -EPIPE || res == -ECONNRESET || res == -ENOTCONN)
     {
       self->m_state.store(connection_state::broken, std::memory_order_release);
     }
@@ -959,11 +967,10 @@ private:
 
   bool finalize_sync() noexcept
   {
+    // Only on_core_error() decides whether an error is fatal to the
+    // connection; a failed round-trip on its own is not.
     if (m_sync_error.load(std::memory_order_acquire) != 0)
-    {
-      m_state.store(connection_state::broken, std::memory_order_release);
       return false;
-    }
 
     if (m_state.load(std::memory_order_acquire) == connection_state::connecting)
     {

--- a/include/libremidi/backends/linux/pipewire/context.hpp
+++ b/include/libremidi/backends/linux/pipewire/context.hpp
@@ -212,6 +212,27 @@ public:
     }
   }
 
+  // Number of independent shared_context() holders currently alive. Copies of
+  // one holder's pointer count once; contexts built directly with make() or
+  // borrow() report 0.
+  std::size_t shared_holders() const noexcept
+  {
+    std::lock_guard lk{m_holders_mtx};
+    return m_shared_holders;
+  }
+
+  // Wraps `self` in a pointer that also counts as one shared holder. Used by
+  // shared_context(); copies of the result share the same holder slot.
+  static std::shared_ptr<context> make_shared_holder(std::shared_ptr<context> self)
+  {
+    if (!self)
+      return {};
+    auto* raw = self.get();
+    auto* tok = new holder_token{std::move(self)};
+    std::shared_ptr<holder_token> owner{tok, [](holder_token* t) { delete t; }};
+    return std::shared_ptr<context>{std::move(owner), raw};
+  }
+
   bool reconnect()
   {
     // tear_down() stops and destroys the thread loop, so reconnect MUST run
@@ -221,6 +242,19 @@ public:
     // ('recurse > 0' failure) and the invoke never completes (hang).
     if (is_in_loop_thread())
       return false;
+
+    // Held across the rebuild so a holder arriving mid-reconnect waits and
+    // then observes the new handles rather than the ones being freed.
+    std::lock_guard holders_lk{m_holders_mtx};
+
+    // tear_down() frees the loop, core and context this connection is built
+    // on. Other shared_context() holders may own pw_streams and proxies bound
+    // to them, and the rebuild cannot migrate those, so a context that is
+    // shared is never torn down on one holder's behalf.
+    if (m_shared_holders > 1)
+      return false;
+
+    dispatch_invalidated();
 
     tear_down(/*final=*/false);
     m_state.store(connection_state::connecting, std::memory_order_release);
@@ -397,6 +431,15 @@ public:
     return add_subscriber(m_subs_state, std::move(fn));
   }
 
+  // Fires from reconnect(), on the calling thread, immediately before the
+  // loop, context and core are destroyed — they are still valid inside the
+  // callback, which is where a holder must destroy the pw_streams and proxies
+  // it built on them. The loop lock is not held; take it as usual.
+  [[nodiscard]] subscription on_invalidated(std::function<void()> fn)
+  {
+    return add_subscriber(m_subs_invalidated, std::move(fn));
+  }
+
   // Live events only; observer's notify_in_constructor handles the
   // initial walk (matches alsa_seq / jack convention).
   [[nodiscard]] subscription on_node_added(std::function<void(const node_info&)> fn)
@@ -425,6 +468,7 @@ public:
     // destroy state captured by the subscriber lambda.
     invoke_sync([this, id] {
       remove_subscriber(m_subs_state, id);
+      remove_subscriber(m_subs_invalidated, id);
       remove_subscriber(m_subs_node_added, id);
       remove_subscriber(m_subs_node_removed, id);
       remove_subscriber(m_subs_port_added, id);
@@ -513,6 +557,29 @@ private:
   bool m_owns_loop{true};
   bool m_owns_core{true};
 
+  // Recursive: an on_invalidated subscriber may release or acquire a holder
+  // from inside reconnect(), which runs under this lock.
+  mutable std::recursive_mutex m_holders_mtx;
+  std::size_t m_shared_holders{0};
+
+  struct holder_token
+  {
+    std::shared_ptr<context> ctx;
+    explicit holder_token(std::shared_ptr<context> c)
+        : ctx{std::move(c)}
+    {
+      std::lock_guard lk{ctx->m_holders_mtx};
+      ++ctx->m_shared_holders;
+    }
+    ~holder_token()
+    {
+      std::lock_guard lk{ctx->m_holders_mtx};
+      --ctx->m_shared_holders;
+    }
+    holder_token(const holder_token&) = delete;
+    holder_token& operator=(const holder_token&) = delete;
+  };
+
   std::atomic<connection_state> m_state{connection_state::connecting};
   std::atomic<std::uint32_t> m_generation{0};
 
@@ -534,6 +601,7 @@ private:
   };
 
   subscriber_list<std::function<void(connection_state)>> m_subs_state;
+  subscriber_list<std::function<void()>> m_subs_invalidated;
   subscriber_list<std::function<void(const node_info&)>> m_subs_node_added;
   subscriber_list<std::function<void(std::uint32_t)>> m_subs_node_removed;
   subscriber_list<std::function<void(const port_info&)>> m_subs_port_added;
@@ -557,6 +625,21 @@ private:
         list.list.begin(), list.list.end(), [id](const auto& s) { return s.id == id; });
     if (it != list.list.end())
       list.list.erase(it);
+  }
+
+  void dispatch_invalidated()
+  {
+    for (const auto& sub : m_subs_invalidated.list)
+      if (sub.fn)
+      {
+        try
+        {
+          sub.fn();
+        }
+        catch (...)
+        {
+        }
+      }
   }
 
   void dispatch_state(connection_state s)

--- a/tests/integration/pipewire_context_error_scope.cpp
+++ b/tests/integration/pipewire_context_error_scope.cpp
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BSL-1.0
+//
+// Regression test: pw_core_events::error carries the id of the proxy the error
+// belongs to. Only id == PW_ID_CORE describes the connection itself; every
+// other id is a per-object error, which the daemon emits routinely (binding a
+// global that just disappeared, a stream whose autoconnect target is not up
+// yet, an unknown factory name). Treating those as connection loss marked the
+// whole context broken, and callers reacted by reconnecting it — which frees
+// the loop other holders still use.
+//
+// Both cases below are per-object -ENOENT and must leave the context connected.
+// Requires a running PipeWire daemon; skips (exit 0) if none is reachable.
+
+#include <libremidi/backends/linux/pipewire/context.hpp>
+#include <libremidi/backends/linux/pipewire/instance.hpp>
+#include <libremidi/backends/linux/pipewire/loader.hpp>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+
+namespace lpw = libremidi::pipewire;
+
+static void arm_watchdog(int seconds)
+{
+  std::thread(
+      [seconds]
+      {
+        std::this_thread::sleep_for(std::chrono::seconds(seconds));
+        std::fprintf(stderr, "FAIL: watchdog timeout (%ds) - likely deadlock\n", seconds);
+        std::fflush(stderr);
+        std::_Exit(EXIT_FAILURE);
+      })
+      .detach();
+}
+
+static int check_survived(lpw::context& ctx, const char* what)
+{
+  // The sync round-trip must still complete: the object error does not cancel
+  // the core's `done` reply.
+  const bool synced = ctx.synchronize();
+  const bool broken = ctx.state() == lpw::connection_state::broken;
+
+  if (broken || !ctx.ok() || !synced)
+  {
+    std::fprintf(
+        stderr,
+        "FAIL: %s left the context unusable (ok=%d broken=%d synchronize=%d);\n"
+        "      a per-object error must not mark the connection broken\n",
+        what, (int)ctx.ok(), (int)broken, (int)synced);
+    std::fflush(stderr);
+    return 1;
+  }
+  std::printf("ok: %s left the context connected\n", what);
+  return 0;
+}
+
+int main()
+{
+  auto& pw = lpw::load();
+  if (!pw.thread_available)
+  {
+    std::printf("libpipewire thread-loop not available; skipping\n");
+    return 0;
+  }
+
+  auto inst = lpw::shared_instance();
+  if (!inst)
+  {
+    std::printf("pw_init failed; skipping\n");
+    return 0;
+  }
+
+  arm_watchdog(60);
+
+  int failures = 0;
+
+  // 1. Binding a global that does not exist. The daemon answers with -ENOENT
+  //    on the registry proxy. This is what a real graph race looks like: a
+  //    node vanishes between the registry event and the bind.
+  {
+    auto ctx = lpw::context::make(inst);
+    if (!ctx || !ctx->ok())
+    {
+      std::printf("cannot connect to pipewire daemon; skipping\n");
+      return 0;
+    }
+
+    ctx->with_lock(
+        [&]
+        {
+          (void)pw_registry_bind(
+              ctx->registry(), 0xFFFFFF00u, PW_TYPE_INTERFACE_Node, PW_VERSION_NODE, 0);
+        });
+
+    failures += check_survived(*ctx, "pw_registry_bind() of an unknown global");
+  }
+
+  // 2. Creating an object from a factory the daemon does not have, which is
+  //    the shape of a pw_stream whose autoconnect target is not up yet.
+  {
+    auto ctx = lpw::context::make(inst);
+    if (!ctx || !ctx->ok())
+    {
+      std::printf("cannot connect to pipewire daemon; skipping\n");
+      return 0;
+    }
+
+    ctx->with_lock(
+        [&]
+        {
+          (void)pw_core_create_object(
+              ctx->pw_core_ptr(), "libremidi-no-such-factory", PW_TYPE_INTERFACE_Node,
+              PW_VERSION_NODE, nullptr, 0);
+        });
+
+    failures += check_survived(*ctx, "pw_core_create_object() with an unknown factory");
+  }
+
+  // 3. The context must keep working afterwards, not just report connected.
+  {
+    auto ctx = lpw::context::make(inst);
+    if (!ctx || !ctx->ok())
+      return failures == 0 ? 0 : EXIT_FAILURE;
+
+    ctx->with_lock(
+        [&]
+        {
+          (void)pw_registry_bind(
+              ctx->registry(), 0xFFFFFF01u, PW_TYPE_INTERFACE_Node, PW_VERSION_NODE, 0);
+        });
+
+    for (int i = 0; i < 10; ++i)
+    {
+      if (!ctx->synchronize())
+      {
+        std::fprintf(stderr, "FAIL: synchronize() failed after a per-object error\n");
+        std::fflush(stderr);
+        ++failures;
+        break;
+      }
+    }
+    if (ctx->snapshot().nodes.empty())
+    {
+      std::fprintf(stderr, "FAIL: registry walk produced no nodes\n");
+      std::fflush(stderr);
+      ++failures;
+    }
+  }
+
+  if (failures != 0)
+    return EXIT_FAILURE;
+
+  std::printf("PASS: pipewire_context_error_scope\n");
+  return 0;
+}

--- a/tests/integration/pipewire_context_shared_teardown.cpp
+++ b/tests/integration/pipewire_context_shared_teardown.cpp
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: BSL-1.0
+//
+// Regression test: shared_context() hands the same context to independent
+// subsystems (MIDI backends, an audio engine, video devices). reconnect()
+// destroys the pw_core, pw_context and pw_thread_loop that connection is built
+// on and builds new ones, so any pw_stream another holder created keeps
+// pointing at the freed loop — pw_stream_destroy then faults on it.
+//
+// A context with more than one shared holder must therefore refuse to be torn
+// down, and must keep serving the handles its holders already took. A sole
+// holder may still reconnect, and gets on_invalidated() first so it can drop
+// what it built while the loop is still alive.
+//
+// Requires a running PipeWire daemon; skips (exit 0) if none is reachable.
+
+#include <libremidi/backends/linux/pipewire/context.hpp>
+#include <libremidi/backends/linux/pipewire/instance.hpp>
+#include <libremidi/backends/linux/pipewire/loader.hpp>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+
+namespace lpw = libremidi::pipewire;
+
+static void arm_watchdog(int seconds)
+{
+  std::thread(
+      [seconds]
+      {
+        std::this_thread::sleep_for(std::chrono::seconds(seconds));
+        std::fprintf(stderr, "FAIL: watchdog timeout (%ds) - likely deadlock\n", seconds);
+        std::fflush(stderr);
+        std::_Exit(EXIT_FAILURE);
+      })
+      .detach();
+}
+
+static int fail(const char* msg)
+{
+  std::fprintf(stderr, "FAIL: %s\n", msg);
+  std::fflush(stderr);
+  return 1;
+}
+
+int main()
+{
+  auto& pw = lpw::load();
+  if (!pw.thread_available || !pw.stream_available)
+  {
+    std::printf("libpipewire thread-loop/stream not available; skipping\n");
+    return 0;
+  }
+
+  // Holder A stands in for one subsystem (say the audio engine), holder B for
+  // another (a video device) — each acquires the process-wide connection
+  // without knowing the other exists.
+  auto a = lpw::shared_context();
+  if (!a || !a->ok())
+  {
+    std::printf("cannot connect to pipewire daemon; skipping\n");
+    return 0;
+  }
+  auto b = lpw::shared_context();
+  if (!b)
+    return fail("shared_context() returned nothing on the second call");
+  if (a.get() != b.get())
+    return fail("shared_context() did not return the same context twice");
+
+  arm_watchdog(60);
+
+  int failures = 0;
+
+  if (a->shared_holders() != 2)
+  {
+    std::fprintf(
+        stderr, "FAIL: expected 2 shared holders, got %zu\n", a->shared_holders());
+    std::fflush(stderr);
+    ++failures;
+  }
+
+  // B builds a pw_stream on the shared core, exactly as the video devices do.
+  pw_stream* stream = nullptr;
+  auto* const loop_before = b->thread_loop_handle();
+  auto* const core_before = b->pw_core_ptr();
+
+  b->with_lock(
+      [&]
+      {
+        auto* props = pw.properties_new(
+            PW_KEY_MEDIA_TYPE, "Video", PW_KEY_MEDIA_CATEGORY, "Source", nullptr);
+        stream = pw.stream_new(b->pw_core_ptr(), "libremidi-shared-holder", props);
+      });
+  if (!stream)
+    return fail("could not create a pw_stream on the shared core");
+
+  // A now decides the connection needs rebuilding. B's stream lives on the
+  // loop and core tear_down() would free, and A has no way to know that.
+  const bool reconnected = a->reconnect();
+  if (reconnected)
+    failures += fail(
+        "reconnect() tore down a context still held by another client;\n"
+        "      every pw_stream that holder built now points at a freed loop");
+
+  if (b->thread_loop_handle() != loop_before)
+    failures += fail("the thread loop another holder is using was replaced");
+  if (b->pw_core_ptr() != core_before)
+    failures += fail("the core another holder is using was replaced");
+  if (!b->ok())
+    failures += fail("the shared context stopped being usable");
+
+  // Must not fault: this is the pw_stream_destroy that crashed in the field.
+  b->with_lock([&] { pw.stream_destroy(stream); });
+  stream = nullptr;
+  std::printf("ok: pw_stream_destroy() survived a concurrent reconnect() attempt\n");
+
+  if (!b->synchronize())
+    failures += fail("the shared context stopped synchronizing");
+
+  // Sole holder: reconnect is allowed again, and must announce itself first.
+  b.reset();
+  if (a->shared_holders() != 1)
+  {
+    std::fprintf(
+        stderr, "FAIL: expected 1 shared holder after release, got %zu\n",
+        a->shared_holders());
+    std::fflush(stderr);
+    ++failures;
+  }
+
+  bool invalidated = false;
+  bool handles_live_in_callback = false;
+  auto sub = a->on_invalidated(
+      [&]
+      {
+        invalidated = true;
+        // The loop and core must still be alive here — that is the whole
+        // point of the callback: it is when a holder can still drop what it
+        // built on them.
+        handles_live_in_callback
+            = a->thread_loop_handle() != nullptr && a->pw_core_ptr() != nullptr;
+      });
+
+  if (!a->reconnect())
+    failures += fail("sole-holder reconnect() was refused");
+  if (!invalidated)
+    failures += fail("on_invalidated() did not fire before teardown");
+  if (!handles_live_in_callback)
+    failures += fail("handles were already dead when on_invalidated() fired");
+  if (!a->ok() || !a->synchronize())
+    failures += fail("context is not usable after a sole-holder reconnect");
+
+  if (failures != 0)
+    return EXIT_FAILURE;
+
+  std::printf("PASS: pipewire_context_shared_teardown\n");
+  return 0;
+}


### PR DESCRIPTION
Two related defects in the PipeWire backend's shared context. Together they form one
cascade: a routine per-object `-ENOENT` is misread as connection loss, which triggers a
reconnect, which frees a `pw_thread_loop` other holders are still using — SIGSEGV.

### 1. `on_core_error` ignored the `id` argument

`pw_core_events::error` documents (`pipewire/core.h:128-146`) that *"the id argument is
the proxy object where the error occurred"*, and `PW_ID_CORE == 0`. The handler discarded
`id` and latched `connection_state::broken` for any of `-EPIPE / -ECONNRESET / -ENOENT /
-ENOTCONN`, regardless of which object failed.

The daemon emits per-object errors routinely. Observed on a live daemon:

```
core error: id=37 seq=39 res=-2 (-ENOENT) msg=no global 4294967040
core error: id=37 seq=39 res=-2 (-ENOENT) msg=unknown factory name libremidi-no-such-factory
  => ok=0 broken=1 sync=0
```

`id=37`, not `0` — a healthy socket marked broken. Any client binding a stale global, or
requesting a factory that isn't present, poisoned the whole shared context.

Fixed by scoping the check to `id == PW_ID_CORE`. `-ENOENT` is also dropped from the fatal
set even on the core: it means "no such object/factory", not a dead socket — genuine loss
surfaces as `-EPIPE` / `-ECONNRESET` / `-ENOTCONN`. Additionally `finalize_sync()` no
longer latches `broken` on its own, since a per-object error could poison the sync path
by the same route.

### 2. `reconnect()` tore down a context other holders still use

`shared_context()` is a process-wide singleton, but `reconnect()` did
`pw_core_disconnect` + `pw_context_destroy` + `pw_thread_loop_destroy` and rebuilt,
notifying nobody. Every `pw_stream` another holder built on that core was left pointing at
freed memory:

```
before reconnect: loop=0x...4650 core=0x...9fb0 stream=0x...5520
after reconnect:  loop=0x...6200 core=0x...9b30
about to pw_stream_destroy() the other holder's stream...
*** SegFault
```

Fixed with two mechanisms, because neither is sufficient alone:
- `reconnect()` refuses while more than one holder is registered — but that alone does not
  protect a *sole* holder's own streams;
- a new `on_invalidated()` callback fires before teardown, while handles are still valid —
  but notification alone is cooperative, so an unmodified holder would still crash.

Holders are counted with an explicit token handed out by `shared_context()` rather than
`use_count()`, which counts temporaries and cannot be checked atomically against the
teardown.

### Verification

- New integration tests alongside the existing `pipewire_context_*` ones. Both guards were
  negative-controlled by disabling them individually: gate off → SegFault; callback off →
  `on_invalidated() did not fire before teardown`.
- 16/16 ctest green, stable over 10 repeats. The existing
  `pipewire_context_{sync,reconnect,subscriptions}` tests are unaffected — they use
  `context::make()`, which reports zero holders, so `reconnect()` behaves as before.
- MIDI paths checked for regression against a pristine tree: same ports enumerated,
  virtual in/out open, send works.
- Each commit builds and tests green independently.

Found while debugging a crash in [ossia/score](https://github.com/ossia/score), where
three independent subsystems (two video devices and the audio engine) share one context.
