### PR TITLE
ci: use Ninja for all FreeBSD build modes

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -256,13 +256,9 @@ jobs:
           whoami
           env
           freebsd-version
-          CMAKE_GENERATOR=
-          if [ "${{ matrix.library_mode }}" = "MODULE" ]; then
-            CMAKE_GENERATOR=-GNinja
-          fi
 
           cmake -S . -B build \
-            $CMAKE_GENERATOR \
+            -GNinja \
             -DLIBREMIDI_FIND_BOOST=${{ matrix.boost }} \
             -DLIBREMIDI_LIBRARY_MODE=${{ matrix.library_mode }} \
             -DLIBREMIDI_EXAMPLES=1 \


### PR DESCRIPTION
## Problem

The four non-`MODULE` FreeBSD matrix jobs (`LIBRARY` and `HEADER_ONLY`, boost 0 and 1) fail immediately after configure:

```
-- Build files have been written to: /home/runner/work/libremidi/libremidi/build
make: option requires an argument -- j
usage: make [-BeikNnqrSstWwX] ...
##[error]ssh exited with code 2
```

`cmake --build build --parallel` with no job count passes a bare `-j` to the build tool. GNU make reads that as "unlimited jobs"; FreeBSD's `bmake` requires an argument to `-j` and exits 2.

The VM `prepare` step installs `jackit boost-libs cmake git ninja` — no `gmake` — so with the default Unix Makefiles generator `CMAKE_MAKE_PROGRAM` resolves to `/usr/bin/make`, i.e. bmake.

That is exactly why 2 of 6 jobs passed: `-GNinja` was set only for `MODULE`.

| library_mode | generator | result |
|---|---|---|
| `MODULE` | Ninja | :white_check_mark: |
| `LIBRARY`, `HEADER_ONLY` | Unix Makefiles → bmake | :x: |

## Fix

Drop the conditional and use Ninja for every mode. ninja is already installed in `prepare`, and it makes the FreeBSD leg consistent with the rest of the matrix.

The alternative — `cmake --build build --parallel $(sysctl -n hw.ncpu)` — would also work, but would need the same treatment on the `--target install` invocation.

Nothing about the FreeBSD *build* was broken: configure completes cleanly (ALSA correctly skipped, JACK dynamic loading selected). This was purely the build invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jew8MXh98AHvSZBxz7Wn5